### PR TITLE
Added support for epoll/kqueue native event loops

### DIFF
--- a/eureka-dns-server-standalone/build.gradle
+++ b/eureka-dns-server-standalone/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
   compile           "info.picocli:picocli:3.9.3"
   compile           "ch.qos.logback:logback-classic"
+  compile           "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64"
 
   compile           project(":eureka-dns-server")
 }

--- a/eureka-dns-server-standalone/src/test/groovy/com/github/bfg/eureka/dns/DnsServerConfigSpec.groovy
+++ b/eureka-dns-server-standalone/src/test/groovy/com/github/bfg/eureka/dns/DnsServerConfigSpec.groovy
@@ -1,0 +1,6 @@
+package com.github.bfg.eureka.dns
+
+import spock.lang.Specification
+
+class DnsServerConfigSpec extends Specification {
+}

--- a/eureka-dns-server/build.gradle
+++ b/eureka-dns-server/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
   compile           "com.netflix.eureka:eureka-client"
   compile           "io.netty:netty-codec-dns"
+  compileOnly       "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64"
 
   testCompile       "com.google.inject:guice:4.2.2"
   testCompile       "com.fasterxml.jackson.core:jackson-databind:2.6.5"

--- a/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/EurekaDnsServer.java
+++ b/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/EurekaDnsServer.java
@@ -7,6 +7,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
@@ -23,28 +24,52 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.github.bfg.eureka.dns.Utils.*;
+import static com.github.bfg.eureka.dns.Utils.allFutures;
+import static com.github.bfg.eureka.dns.Utils.toCompletableFuture;
 
 /**
  * Eureka DNS server.
  */
 @Slf4j
 public final class EurekaDnsServer implements Closeable {
-    private final DnsServerConfig config;
-    private final EventLoopGroup elg;
-    private final boolean shutdownElg;
-    private final DnsQueryHandler handler;
-    private final CompletableFuture<EurekaDnsServer> completedFuture = CompletableFuture.completedFuture(this);
+    /**
+     * Native event loop class -> channel class name mapping.
+     */
+    private static final Map<String, String> NATIVE_ELG_CLASS_NAME_MAPPING = createChannelClassStringMapping();
 
-    private volatile CompletableFuture<EurekaDnsServer> shutdownFuture = new CompletableFuture<>();
+    /**
+     * Native EventLoopGroup class -> channel class mapping.
+     */
+    private static final Map<Class<? extends EventLoopGroup>, Class<? extends DatagramChannel>> NATIVE_ELG_CLASS_MAPPING
+            = createChannelClassMapping();
+
+    private final CompletableFuture<EurekaDnsServer> completedFuture = CompletableFuture.completedFuture(this);
+    private final CompletableFuture<EurekaDnsServer> startupFuture = new CompletableFuture<>();
+    private final CompletableFuture<EurekaDnsServer> shutdownFuture = new CompletableFuture<>();
+
+    private final DnsServerConfig config;
+    private final EventLoopGroup eventLoopGroup;
+    private final boolean shutdownElg;
+    private final DnsQueryHandler dnsQueryHandler;
+    private final AtomicBoolean wasStarted = new AtomicBoolean();
+    private final AtomicBoolean wasStopped = new AtomicBoolean();
+
+    /**
+     * List of bound UDP channels, volatile because it can't be created on instance instantiation.
+     */
     private volatile List<Channel> channels;
 
     /**
@@ -52,15 +77,89 @@ public final class EurekaDnsServer implements Closeable {
      *
      * @param config server configuration.
      */
-    public EurekaDnsServer(@NonNull DnsServerConfig config) {
-        this.config = config.validate();
-        this.elg = createEventLoopGroup(config.getEventLoopGroup());
-        this.shutdownElg = (config.getEventLoopGroup() == null);
-        this.handler = new DnsQueryHandler(this.config);
+    EurekaDnsServer(@NonNull DnsServerConfig config) {
+        this(config, new DnsQueryHandler(config));
     }
 
-    private EventLoopGroup createEventLoopGroup(EventLoopGroup elg) {
-        return (elg == null) ? new NioEventLoopGroup(1) : elg;
+    /**
+     * Creates new instance.
+     *
+     * @param config          server configuration.
+     * @param dnsQueryHandler dns query handler
+     */
+    EurekaDnsServer(@NonNull DnsServerConfig config, @NonNull DnsQueryHandler dnsQueryHandler) {
+        this.config = config.validate();
+        this.eventLoopGroup = getOrCreateEventLoopGroup(config);
+        this.shutdownElg = (config.getEventLoopGroup() == null);
+        this.dnsQueryHandler = dnsQueryHandler;
+    }
+
+    /**
+     * Retrieves event loop group from configuration or creates new one.
+     *
+     * @param config config
+     * @return event loop group
+     */
+    private EventLoopGroup getOrCreateEventLoopGroup(@NonNull DnsServerConfig config) {
+        return Optional.ofNullable(config.getEventLoopGroup())
+                .orElseGet(() -> createEventLoopGroup(config));
+    }
+
+    /**
+     * Creates event loop group according to configuration.
+     *
+     * @param config config
+     * @return event loop group
+     */
+    private EventLoopGroup createEventLoopGroup(@NonNull DnsServerConfig config) {
+        val numThreads = getNumThreads(config);
+        val elg = (config.isPreferNativeTransport()) ?
+                createNativeEventLoopGroup(numThreads) : createGenericEventLoopGroup(numThreads);
+        log.info("created new event loop group (workers: {}): {}", numThreads, elg);
+        return elg;
+    }
+
+    /**
+     * Creates generic NIO event loop group.
+     *
+     * @param numThreads number of worker threads.
+     * @return event loop group
+     */
+    private EventLoopGroup createGenericEventLoopGroup(int numThreads) {
+        return new NioEventLoopGroup(numThreads);
+    }
+
+    /**
+     * Creates generic native event loop group.
+     *
+     * @param numThreads number of worker threads.
+     * @return event loop group, may return generic event loop group if native initialization failed.
+     */
+    private EventLoopGroup createNativeEventLoopGroup(int numThreads) {
+        return NATIVE_ELG_CLASS_MAPPING.keySet().stream()
+                .map(clazz -> initEventLoopGroup(clazz, numThreads))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst()
+                .orElseGet(() -> {
+                    log.warn("error initializing native event loop group, fallling back to nio event loop group.");
+                    return createGenericEventLoopGroup(numThreads);
+                });
+    }
+
+    private Optional<EventLoopGroup> initEventLoopGroup(Class<? extends EventLoopGroup> clazz, int numThreads) {
+        try {
+            val constructor = clazz.getConstructor(int.class);
+            return Optional.of(constructor.newInstance(numThreads));
+        } catch (Exception e) {
+            log.debug("exception initializing event loop group {}: {}", clazz.getName(), e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+
+    private int getNumThreads(@NonNull DnsServerConfig config) {
+        val maxThreads = config.getMaxThreads();
+        return (maxThreads < 1) ? Runtime.getRuntime().availableProcessors() : maxThreads;
     }
 
     /**
@@ -76,45 +175,79 @@ public final class EurekaDnsServer implements Closeable {
      * Starts eureka dns server.
      *
      * @return completion stage that is completed when all addresses are bound.
+     * @throws IllegalStateException if this method is invoked more than once on the same instance.
      */
     public CompletionStage<EurekaDnsServer> start() {
-        checkRunning(false);
+        if (!wasStarted.compareAndSet(false, true)) {
+            throw new IllegalStateException("Eureka DNS server start attempt was already done.");
+        }
+
         try {
             return doStart();
         } catch (Exception e) {
-            return failedFuture(e);
+            startupFuture.completeExceptionally(e);
+            return startupFuture;
         }
     }
 
     private CompletionStage<EurekaDnsServer> doStart() {
         log.info("starting eureka DNS server");
 
-        val result = new CompletableFuture<EurekaDnsServer>();
         val bootstrap = new Bootstrap()
-                .group(this.elg)
-                .channel(getChannelClass(elg))
+                .group(eventLoopGroup)
+                .channel(getChannelClass(eventLoopGroup))
                 .handler(createChannelHandler())
                 .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
-                .option(ChannelOption.SO_REUSEADDR, true)
-                .validate();
+                .option(ChannelOption.SO_REUSEADDR, true);
 
-        final List<CompletableFuture<Channel>> channelFutures = getListeningAddresses().stream()
-                .map(addr -> bindAddress(bootstrap, addr))
+        // SO_REUSEPORT improves performance because multiple event loops are tied to different CPU cores,
+        // but it requires native transport
+        //
+        // make sure that you check bindAddress()
+        if (isNativeTransport(eventLoopGroup)) {
+            Optional.ofNullable(ChannelOption.valueOf("io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT"))
+                    .ifPresent(option -> {
+                        log.debug("setting channel option on a bootstrap: {}", option);
+                        bootstrap.option(option, true);
+                    });
+        }
+
+        // validate bootstrap early.
+        bootstrap.validate();
+
+        // bind all listening addresses
+        val boundChannelFutures = getListeningAddresses().stream()
+                .flatMap(addr -> bindAddress(bootstrap, addr))
                 .collect(Collectors.toList());
 
-        // start listening
-        allFutures(channelFutures)
+        allFutures(boundChannelFutures)
                 .thenRun(() -> {
-                    log.info("started eureka DNS server [{} listening socket(s)]", channelFutures.size());
-                    this.channels = toChannels(channelFutures);
-                    result.complete(this);
+                    channels = toChannels(boundChannelFutures);
+                    logBoundChannels(channels);
+                    log.info("started eureka DNS server [{} channel(s)]", boundChannelFutures.size());
+                    startupFuture.complete(this);
                 })
                 .exceptionally(t -> {
-                    result.completeExceptionally(t);
+                    startupFuture.completeExceptionally(t);
+                    shutdownFuture.completeExceptionally(t);
                     return null;
                 });
 
-        return result;
+        return startupFuture;
+    }
+
+    /**
+     * Logs bound channels.
+     *
+     * @param channels channels
+     */
+    private void logBoundChannels(List<Channel> channels) {
+        channels.stream()
+                .filter(e -> e instanceof DatagramChannel)
+                .map(e -> (DatagramChannel) e)
+                .map(DatagramChannel::localAddress)
+                .distinct()
+                .forEach(e -> log.info("listening on {}", e));
     }
 
     /**
@@ -130,13 +263,22 @@ public final class EurekaDnsServer implements Closeable {
                 .collect(Collectors.toList());
     }
 
-    private CompletableFuture<Channel> bindAddress(Bootstrap bootstrap, InetSocketAddress addr) {
-        log.debug("binding address [{}]:{}", addr.getAddress(), addr.getPort());
-        return toCompletableFuture(bootstrap.bind(addr.getAddress(), addr.getPort()))
-                .thenApply(ch -> {
-                    log.info("listening on [{}]:{}", addr.getAddress().getHostAddress(), addr.getPort());
-                    return ch;
-                });
+    /**
+     * Binds given address on a bootstrap. This method binds given address as many times as there are worker threads in
+     * event loop group if it's using native transport which leads to per-cpu to almost linear performance scaling.
+     *
+     * @param bootstrap bootstrap
+     * @param addr      address to bind
+     * @return stream of futures of bound channels.
+     * @see #isNativeTransport(EventLoopGroup)
+     * @see #getEventLoopGroupThreads(EventLoopGroup)
+     */
+    private Stream<CompletableFuture<Channel>> bindAddress(Bootstrap bootstrap, InetSocketAddress addr) {
+        val numTimes = isNativeTransport(eventLoopGroup) ? getEventLoopGroupThreads(eventLoopGroup) : 1;
+        log.debug("binding address ({} times) [{}]:{}", numTimes, addr.getAddress(), addr.getPort());
+
+        return IntStream.range(0, numTimes)
+                .mapToObj(idx -> toCompletableFuture(bootstrap.bind(addr.getAddress(), addr.getPort())));
     }
 
     private List<InetSocketAddress> getListeningAddresses() {
@@ -185,10 +327,15 @@ public final class EurekaDnsServer implements Closeable {
      * Shuts down the server.
      *
      * @return completion stage which is completed when all listeners are shut down.
+     * @throws IllegalStateException if server is not running or has been already stopped.
      */
     public CompletionStage<EurekaDnsServer> stop() {
-        checkRunning(true);
-        checkHasBeenShutdown();
+        if (!isRunning()) {
+            throw new IllegalStateException("Eureka DNS server is not running.");
+        }
+        if (!wasStopped.compareAndSet(false, true)) {
+            throw new IllegalStateException("Instance can't be stopped more than once.");
+        }
 
         log.info("stopping eureka DNS server.");
         val result = new CompletableFuture<EurekaDnsServer>();
@@ -201,11 +348,11 @@ public final class EurekaDnsServer implements Closeable {
                 .thenCompose(e -> shutdownEvenLoopGroup())
                 .thenRun(() -> {
                     log.info("eureka DNS server stopped.");
-                    shutdownFuture().complete(this);
+                    shutdownFuture.complete(this);
                     result.complete(this);
                 })
                 .exceptionally(t -> {
-                    shutdownFuture().completeExceptionally(t);
+                    shutdownFuture.completeExceptionally(t);
                     result.completeExceptionally(t);
                     return null;
                 })
@@ -226,33 +373,10 @@ public final class EurekaDnsServer implements Closeable {
      * @return true/false
      */
     private boolean isRunning() {
-        val channels = this.channels;
-        return (channels != null && !channels.isEmpty());
-    }
-
-    /**
-     * Checks whether server is running or not.
-     *
-     * @param mustBeRunning flag to check against whether server is running.
-     * @throws IllegalStateException if {@code mustBeStarted == true} and the server is not running and in opposite
-     *                               case.
-     */
-    private void checkRunning(boolean mustBeRunning) {
-        val isRunning = isRunning();
-        if (mustBeRunning && !isRunning) {
-            throw new IllegalStateException("Eureka DNS server is not running.");
-        } else if (!mustBeRunning && isRunning) {
-            throw new IllegalStateException("Eureka DNS server is running.");
-        }
-    }
-
-    /**
-     * Checks whether server is currently in shutdown procedure.
-     */
-    private void checkHasBeenShutdown() {
-        if (shutdownFuture.isDone()) {
-            throw new IllegalStateException("Server has already been shut down.");
-        }
+        return startupFuture.isDone() &&
+                !startupFuture.isCancelled() &&
+                !startupFuture.isCompletedExceptionally() &&
+                !shutdownFuture.isDone();
     }
 
     private CompletableFuture<Channel> closeChannel(@NonNull Channel channel) {
@@ -267,13 +391,9 @@ public final class EurekaDnsServer implements Closeable {
      */
     @SneakyThrows
     public void run() {
-        start().thenCompose(EurekaDnsServer::shutdownFuture)
+        start().thenCompose(e -> shutdownFuture)
                 .toCompletableFuture()
                 .get();
-    }
-
-    private CompletableFuture<EurekaDnsServer> shutdownFuture() {
-        return this.shutdownFuture;
     }
 
     private ChannelInitializer<DatagramChannel> createChannelHandler() {
@@ -284,36 +404,93 @@ public final class EurekaDnsServer implements Closeable {
                 ch.pipeline()
                         .addLast(new DatagramDnsQueryDecoder())
                         .addLast(new DatagramDnsResponseEncoder())
-                        .addLast(me.handler);
+                        .addLast(me.dnsQueryHandler);
                 log.debug("initialized netty channel: {}", ch);
             }
         };
     }
 
+    /**
+     * Returns channel class for given event loop group.
+     *
+     * @param elg event loop group
+     * @return channel class
+     * @throws IllegalArgumentException if channel class cannot be obtained.
+     */
     private Class<? extends Channel> getChannelClass(EventLoopGroup elg) {
         if (elg instanceof NioEventLoopGroup) {
             return NioDatagramChannel.class;
         }
-        // this is so ugly...
-        if (elg.getClass().getName().toLowerCase().contains("epoll")) {
-            return initChannelClass("io.netty.channel.epoll.EpollDatagramChannel");
-        }
-        throw new IllegalArgumentException("Unknown event loop group type: " + elg.getClass().getName());
+
+        return Optional.ofNullable(NATIVE_ELG_CLASS_MAPPING.get(elg.getClass()))
+                .orElseThrow(() ->
+                        new IllegalArgumentException("Unknown event loop group type: " + elg.getClass().getName()));
     }
 
-    @SneakyThrows
-    @SuppressWarnings("unchecked")
-    private Class<? extends Channel> initChannelClass(String fqcn) {
-        return ((Class<? extends Channel>) Class.forName(fqcn));
+    /**
+     * Returns number of worker threads in a given event loop group.
+     *
+     * @param elg event loop group
+     * @return number of worker threads
+     */
+    private int getEventLoopGroupThreads(@NonNull EventLoopGroup elg) {
+        if (elg instanceof MultithreadEventLoopGroup) {
+            return ((MultithreadEventLoopGroup) elg).executorCount();
+        }
+        return 1;
+    }
+
+    /**
+     * Tells whether given event loop group uses native transport
+     *
+     * @param elg event loop group
+     * @return true/false
+     */
+    private boolean isNativeTransport(@NonNull EventLoopGroup elg) {
+        return !(elg instanceof NioEventLoopGroup);
     }
 
     @SneakyThrows
     private CompletableFuture<EurekaDnsServer> shutdownEvenLoopGroup() {
         if (shutdownElg) {
-            log.debug("shutting down event loop group: {}", elg);
-            return toCompletableFuture(elg.shutdownGracefully(0, 1, TimeUnit.SECONDS))
+            log.debug("shutting down event loop group: {}", eventLoopGroup);
+            return toCompletableFuture(eventLoopGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS))
                     .thenCompose(e -> completedFuture);
         }
         return completedFuture;
+    }
+
+    private static Map<String, String> createChannelClassStringMapping() {
+        val map = new LinkedHashMap<String, String>();
+        map.put("io.netty.channel.epoll.EpollEventLoopGroup", "io.netty.channel.epoll.EpollDatagramChannel");
+        map.put("io.netty.channel.kqueue.KQueueEventLoopGroup", "io.netty.channel.kqueue.KQueueDatagramChannel");
+        return Collections.unmodifiableMap(map);
+    }
+
+    private static Map<Class<? extends EventLoopGroup>, Class<? extends DatagramChannel>> createChannelClassMapping() {
+        val map = new LinkedHashMap<Class<? extends EventLoopGroup>, Class<? extends DatagramChannel>>();
+        NATIVE_ELG_CLASS_NAME_MAPPING.forEach((elgName, chName) -> {
+            final Optional<Class<EventLoopGroup>> eventLoopGroupClassOpt = loadClass(elgName);
+            final Optional<Class<DatagramChannel>> channelClassOpt = loadClass(chName);
+            if (eventLoopGroupClassOpt.isPresent() && channelClassOpt.isPresent()) {
+                map.put(eventLoopGroupClassOpt.get(), channelClassOpt.get());
+            }
+        });
+        return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Loads some class.
+     *
+     * @param fqcn java fqcn
+     * @return optional of loaded class.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> Optional<Class<T>> loadClass(@NonNull String fqcn) {
+        try {
+            return Optional.ofNullable((Class<T>) Class.forName(fqcn));
+        } catch (ClassNotFoundException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/scripts/performance-test.sh
+++ b/scripts/performance-test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+generate_queries() {
+  local code=""
+  read -d '' code <<-EOF
+my @hosts = @ARGV;
+die "Usage: \$0 service-a [[service-b] ...]\n" unless (@hosts);
+
+##################################################################
+my \$num = \$#hosts + 1;
+while (1) {
+  my \$idx = rand(\$num);
+  print \$hosts[\$idx], " A\\\\n";
+}
+EOF
+
+  perl -e "$code" "$@"
+}
+
+if [ -z "$1" ]; then
+  cat <<EOF
+USAGE: $0 <dns-name> <dns-name> ...
+
+EXAMPLE:
+  $0 {some-service,foo,bar,database,nginx,web,api}.service.eureka
+
+EOF
+  exit 1
+fi
+
+generate_queries "$@" | dnsperf -s 127.0.0.1 -p 5353 -l 20 -c 100
+
+# vim:shiftwidth=2 softtabstop=2 expandtab
+# EOF


### PR DESCRIPTION
* epoll/kqueue support
* standalone: include epoll x86_64 dependency by default
* use SO_REUSEPORT socket option for horizontal multi-core scalability
  when native event loop implementation is available