### PR TITLE
Added spring support to the codebase.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ jobs:
           - v3-dependencies-{{ checksum "build.gradle" }}
           - v3-dependencies-
 
+      - run:
+          name: Ensure that dig(1) is installed
+          command: sudo apt install dnsutils
+
       # run tests!
       - run:
           name: Build the project and run tests
@@ -38,8 +42,9 @@ jobs:
             - ~/.gradle
           key: v3-dependencies-{{ checksum "build.gradle" }}
 
-      # upload jacoco reports to codecov
-      - run: bash <(curl -s https://codecov.io/bash)
+      - run:
+          name: Upload test coverage reports
+          command: bash <(curl -s https://codecov.io/bash)
 
       # setup remote docker
       - setup_remote_docker:

--- a/eureka-dns-server/build.gradle
+++ b/eureka-dns-server/build.gradle
@@ -21,7 +21,6 @@ dependencies {
   testCompile       "com.fasterxml.jackson.core:jackson-databind:2.6.5"
   testCompile       "org.slf4j:jcl-over-slf4j"
   testCompile       "ch.qos.logback:logback-classic"
-  testCompile       "dnsjava:dnsjava:2.1.8"
 
   // spring test support
   testCompile       "org.yaml:snakeyaml:1.23"

--- a/eureka-dns-server/build.gradle
+++ b/eureka-dns-server/build.gradle
@@ -11,14 +11,23 @@ dependencies {
   compile           "io.netty:netty-codec-dns"
   compileOnly       "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64"
 
+  // spring support
+  compileOnly       "org.springframework:spring-context:"
+  compileOnly       "org.springframework.boot:spring-boot"
+  compileOnly       "org.springframework.boot:spring-boot-autoconfigure"
+
+  // tests
   testCompile       "com.google.inject:guice:4.2.2"
   testCompile       "com.fasterxml.jackson.core:jackson-databind:2.6.5"
-  testCompile       "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64"
   testCompile       "org.slf4j:jcl-over-slf4j"
   testCompile       "ch.qos.logback:logback-classic"
   testCompile       "dnsjava:dnsjava:2.1.8"
+
+  // spring test support
+  testCompile       "org.yaml:snakeyaml:1.23"
   testCompile       "org.spockframework:spock-spring"
-  testCompile       "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
+  testCompile       "org.springframework.boot:spring-boot-starter-web"
+  testCompile       "org.springframework.boot:spring-boot-starter-test"
 }
 
 // vim:shiftwidth=2 softtabstop=2 expandtab

--- a/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/DnsServerConfig.java
+++ b/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/DnsServerConfig.java
@@ -5,6 +5,7 @@ import io.netty.channel.EventLoopGroup;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -15,6 +16,7 @@ import java.util.Set;
  */
 @Data
 @Accessors(chain = true)
+@ConfigurationProperties("eureka.dns.server")
 public final class DnsServerConfig implements Cloneable {
     /**
      * UDP listening port.

--- a/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/EurekaDnsServer.java
+++ b/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/EurekaDnsServer.java
@@ -372,7 +372,7 @@ public final class EurekaDnsServer implements Closeable {
      *
      * @return true/false
      */
-    private boolean isRunning() {
+    public boolean isRunning() {
         return startupFuture.isDone() &&
                 !startupFuture.isCancelled() &&
                 !startupFuture.isCompletedExceptionally() &&

--- a/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/EurekaDnsServer.java
+++ b/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/EurekaDnsServer.java
@@ -77,7 +77,7 @@ public final class EurekaDnsServer implements Closeable {
      *
      * @param config server configuration.
      */
-    EurekaDnsServer(@NonNull DnsServerConfig config) {
+    public EurekaDnsServer(@NonNull DnsServerConfig config) {
         this(config, new DnsQueryHandler(config));
     }
 

--- a/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/spring/EnableEurekaDnsServer.java
+++ b/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/spring/EnableEurekaDnsServer.java
@@ -1,0 +1,22 @@
+package com.github.bfg.eureka.dns.spring;
+
+import com.github.bfg.eureka.dns.DnsServerConfig;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Enables Eureka DNS server by auto-importing {@link EurekaDnsServerConfiguration}.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Import({EurekaDnsServerConfiguration.class, DnsServerConfig.class})
+public @interface EnableEurekaDnsServer {
+}

--- a/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/spring/EurekaDnsServerConfiguration.java
+++ b/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/spring/EurekaDnsServerConfiguration.java
@@ -1,0 +1,41 @@
+package com.github.bfg.eureka.dns.spring;
+
+import com.github.bfg.eureka.dns.DnsServerConfig;
+import com.github.bfg.eureka.dns.EurekaDnsServer;
+import com.netflix.discovery.EurekaClient;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+/**
+ * Eureka DNS server spring auto configuration.
+ */
+@Slf4j
+@Configuration
+public class EurekaDnsServerConfiguration {
+    /**
+     * Creates eureka dns server bean.
+     *
+     * @param config       dns server config
+     * @param eurekaClient eureka client
+     * @return dns server instance.
+     */
+    @Bean
+    @SneakyThrows
+    @ConditionalOnMissingBean
+    @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+    public EurekaDnsServer eurekaDnsServer(@NonNull DnsServerConfig config, @NonNull EurekaClient eurekaClient) {
+        val server = config.clone()
+                .setEurekaClient(eurekaClient)
+                .create();
+
+        log.debug("starting created eureka dns server: {}", server);
+        return server.start().toCompletableFuture().get();
+    }
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/ConfigHolder.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/ConfigHolder.groovy
@@ -1,0 +1,20 @@
+package com.github.bfg.eureka.dns
+
+import groovy.util.logging.Slf4j
+
+/**
+ * Dns server config holder, used for spring-app tests
+ */
+@Slf4j
+class ConfigHolder {
+    private static DnsServerConfig cfg
+
+    static DnsServerConfig get() {
+        cfg
+    }
+
+    static set(DnsServerConfig config) {
+        cfg = config
+        log.info("set config: {}", config)
+    }
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/DnsIntegrationSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/DnsIntegrationSpec.groovy
@@ -1,0 +1,219 @@
+package com.github.bfg.eureka.dns
+
+import com.github.bfg.eureka.dns.client.DnsClient
+import groovy.util.logging.Slf4j
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Slf4j
+@Unroll
+abstract class DnsIntegrationSpec extends Specification {
+    @Shared
+    DnsClient client
+
+    DnsServerConfig getConfig() {
+        TestUtils.defaultConfig()
+    }
+
+    String getDomain() {
+        getConfig().getDomain()
+    }
+
+    def setup() {
+        if (!client) {
+            client = new DnsClient("127.0.0.1", getConfig().getPort())
+        }
+    }
+
+    def lookup(String name, String type = "A", String dnsClass = "IN") {
+        def res = client.resolve(name, type, dnsClass)
+        [res, res.answers, res.authorities, res.additionals]
+    }
+
+    def "should correctly respond to NS query: #name"() {
+        when:
+        def (res, answers, authorities, additionals) = lookup(name, "NS")
+
+        then:
+        res.status == "NOERROR"
+        answers.size() == 1
+        authorities.size() == 0
+        additionals.size() == 1
+
+        // inspect answer record
+        def record = answers.first()
+        record.dnsClass == "IN"
+        record.type == "NS"
+        record.ttl == config.getTtl()
+        record.answer == "ns." + config.getDomain()
+
+        // inspect additionals
+        def additional = additionals.first()
+        additional.dnsClass == "IN"
+        additional.type == "A"
+        additional.ttl == config.getTtl()
+        additional.answer == client.getAddress()
+
+        where:
+        name << [
+                config.getDomain(),
+                "service." + config.getDomain(),
+                "corse.service." + config.getDomain(),
+                "_corse._tcp.service." + config.getDomain(),
+        ]
+    }
+
+    def "should correctly respond to SOA query: #name"() {
+        given:
+        def currentTs = System.currentTimeMillis() / 1000
+        def expectedSerial = (int) currentTs
+
+        when:
+        def (res, answers, authorities, additionals) = lookup(name, "SOA")
+
+        then:
+        res.status == "NOERROR"
+
+        answers.size() == 1
+        authorities.size() == 1
+        additionals.size() == 1
+
+        then:
+
+        // inspect answer record
+        answers[0].dnsClass == "IN"
+        answers[0].type == "SOA"
+        answers[0].ttl == config.getTtl()
+
+        answers[0].nameserver == "ns." + getDomain()
+        answers[0].mbox == "hostmaster." + getDomain()
+        answers[0].serial == expectedSerial || answers[0].serial == (expectedSerial + 1)
+        answers[0].refresh == 3600
+        answers[0].retry == 600
+        answers[0].expire == 86400
+        answers[0].minTtl == 0
+
+        authorities[0].dnsClass == "IN"
+        authorities[0].type == "NS"
+        authorities[0].ttl == config.getTtl()
+        authorities[0].name == name || authorities[0].name == "ns." + getDomain()
+        authorities[0].answer == "ns." + getDomain()
+
+        additionals[0].dnsClass == "IN"
+        additionals[0].type == "A"
+        additionals[0].ttl == config.getTtl()
+        authorities[0].name == name || authorities[0].name == "ns." + getDomain()
+        additionals[0].answer == client.getAddress()
+
+        where:
+        name << [
+                config.getDomain(),
+                "service." + config.getDomain(),
+                "corse.service." + config.getDomain(),
+                "_corse._tcp.service." + config.getDomain(),
+        ]
+    }
+
+    def "should correctly respond to TXT query in default region: #name"() {
+        when:
+        def (res, answers, authorities, additionals) = lookup(name, "TXT")
+
+        then:
+        res.status == "NOERROR"
+
+        answers.size() == getConfig().getMaxResponses()
+        authorities.size() == 0
+        additionals.size() == 0
+
+        answers.each { assert it.dnsClass == "IN" }
+        answers.each { assert it.type == "TXT" }
+        answers.each { assert it.ttl == config.getTtl() }
+        answers.each { assert it.name == name }
+
+        when: "weed out urls"
+        def urls = answers.collect { it.answer }
+
+        then:
+        urls[0] == 'http://host-100.us-west-2.compute.internal:8080/'
+        urls[1] == 'http://host-101.us-west-2.compute.internal/'
+        urls[2] == 'https://host-102.us-west-2.compute.internal/'
+        urls[3] == 'https://host-104.us-west-2.compute.internal:8443/'
+
+        where:
+        name << [
+                "corse.service.${domain}",
+                "corse.service.default.${domain}",
+        ]
+    }
+
+    def "should correctly respond to TXT query in non-default region: #name"() {
+        when:
+        def (res, answers, authorities, additionals) = lookup(name, "TXT")
+
+        then:
+        res.status == "NOERROR"
+
+        answers.size() == 1
+        authorities.size() == 0
+        additionals.size() == 0
+
+        answers[0].dnsClass == "IN"
+        answers[0].type == "TXT"
+        answers[0].ttl == config.getTtl()
+        answers[0].name == name
+        answers[0].answer == "http://host-152.us-west-2.compute.internal:8080/"
+
+        where:
+        name << [
+                "mallorca.service.dc1.${domain}",
+        ]
+    }
+
+    def "should return empty set of TXT records for unknown service"() {
+        when:
+        def (res, answers, authorities, additionals) = lookup("foo.service.${domain}", "TXT")
+
+        then:
+        res.status == "NXDOMAIN"
+        answers.isEmpty()
+        authorities.isEmpty()
+        additionals.isEmpty()
+    }
+
+    //
+    // BEGIN: RFC2782
+    //
+
+    def "should correctly respond SRV records for: #name"() {
+        when:
+        def (res, answers, authorities, additionals) = lookup(name, "SRV")
+
+        then:
+        res.status == "NOERROR"
+
+        answers.size() == config.getMaxResponses()
+        authorities.size() == 0
+        additionals.size() == config.getMaxResponses()
+
+        answers.each { assert it.name.startsWith(name) }
+        answers.each { assert it.ttl == config.getTtl() }
+        answers.each { assert it.dnsClass == "IN" }
+        answers.each { assert it.type == "SRV" }
+        answers.each { assert it.priority == 1 }
+        answers.each { assert it.weight == 10 }
+        answers.each { assert it.port > 0 }
+        answers.each { assert !it.target.isEmpty() }
+
+        where:
+        name << [
+                "corse.service.${domain}",
+                "corse.service.default.${domain}",
+                "_corse._tcp.service.default.${domain}",
+        ]
+    }
+
+    //
+    // END:   RFC2782
+    //
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/EurekaDnsServerITSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/EurekaDnsServerITSpec.groovy
@@ -1,248 +1,26 @@
 package com.github.bfg.eureka.dns
 
+import com.netflix.discovery.EurekaClient
 import groovy.util.logging.Slf4j
-import org.xbill.DNS.Credibility
-import org.xbill.DNS.Lookup
-import org.xbill.DNS.Record
-import org.xbill.DNS.Resolver
-import org.xbill.DNS.SimpleResolver
-import org.xbill.DNS.TXTRecord
-import spock.lang.Ignore
-import spock.lang.Specification
-import spock.lang.Unroll
-
-import static org.xbill.DNS.DClass.IN
-import static org.xbill.DNS.Lookup.HOST_NOT_FOUND
-import static org.xbill.DNS.Lookup.SUCCESSFUL
-import static org.xbill.DNS.Type.A
-import static org.xbill.DNS.Type.NS
-import static org.xbill.DNS.Type.SOA
-import static org.xbill.DNS.Type.SRV
-import static org.xbill.DNS.Type.TXT
+import spock.lang.Shared
 
 @Slf4j
-@Unroll
-abstract class EurekaDnsServerITSpec extends Specification {
-    Resolver resolver
+class EurekaDnsServerITSpec extends DnsIntegrationSpec {
+    static final EurekaClient eurekaClient = FakeEurekaClient.defaults()
 
-    DnsServerConfig getConfig() {
-        TestUtils.defaultConfig()
-    }
-
-    String getDomain() {
-        getConfig().getDomain()
-    }
+    @Shared
+    EurekaDnsServer server
 
     def setup() {
-        resolver = createResolver()
-    }
-
-    Resolver createResolver(boolean edns = false) {
-        def r = new SimpleResolver("127.0.0.1")
-        r.setPort(config.getPort())
-        r.setTimeout(0, 100)
-        r.setIgnoreTruncation(true)
-        r.setTCP(false)
-
-        if (edns) {
-            r.setEDNS(0)
+        if (!server) {
+            def cfg = getConfig().clone()
+                                 .setEurekaClient(eurekaClient)
+            server = new EurekaDnsServer(cfg)
+            server.start()
         }
-
-        r
     }
 
-    Lookup lookup(String name, int type = A) {
-        def l = new Lookup(name, type)
-        l.setResolver(resolver)
-        l.setNdots(0)
-        l.setSearchPath([].toArray(new String[0]))
-        l.setCredibility(Credibility.ANY)
-        l
+    def cleanupSpec() {
+        server?.close()
     }
-
-    List<Record> run(Lookup lookup) {
-        def result = lookup.run()?.toList() ?: []
-        log.info("dns response ({}, {} records): {}", lookup.getErrorString(), result.size(), result)
-        result
-    }
-
-    @Ignore("this test should be enabled only for manual dig(1) checks")
-    def "should run"() {
-        when:
-        Thread.sleep(300_000)
-
-        then:
-        true
-    }
-
-    def "should correctly respond to NS query: #name"() {
-        given:
-        def lookup = lookup(name, NS)
-
-        when:
-        def records = run(lookup)
-
-        then:
-        lookup.getResult() == SUCCESSFUL
-        records.size() == 1
-
-        // inspect answer record
-        def record = records.first()
-        record.getDClass() == IN
-        record.getType() == NS
-        record.getTTL() == config.getTtl()
-        record.rdataToString() == "ns." + config.getDomain() + "."
-
-        where:
-        name << [
-                config.getDomain(),
-                "service." + config.getDomain(),
-                "corse.service." + config.getDomain(),
-                "_corse._tcp.service." + config.getDomain(),
-        ]
-    }
-
-    def "should correctly respond to SOA query: #name"() {
-        given:
-        def lookup = lookup(name, SOA)
-
-        and:
-        def currentTs = System.currentTimeMillis() / 1000
-
-        // SOA serial depends on current unix timestamp, we need to wait until next second
-        def unixTs = (int) currentTs
-        def leftoverToAnotherSec = (int) (currentTs - unixTs) * 1000
-        Thread.sleep(leftoverToAnotherSec + 100)
-
-        def expectedSoa = "^ns.${config.getDomain()}. hostmaster.${config.getDomain()}. \\d+ 3600 600 86400 0\$"
-
-        when:
-        def records = run(lookup)
-
-        then:
-        lookup.getResult() == SUCCESSFUL
-        records.size() == 1
-
-        // inspect answer record
-        def record = records.first()
-        record.getDClass() == IN
-        record.getType() == SOA
-        record.getTTL() == config.getTtl()
-        record.rdataToString().matches(expectedSoa)
-
-        where:
-        name << [
-                config.getDomain(),
-                "service." + config.getDomain(),
-                "corse.service." + config.getDomain(),
-                "_corse._tcp.service." + config.getDomain(),
-        ]
-    }
-
-    def "should correctly respond to TXT query in default region: #name"() {
-        given:
-        def lookup = lookup(name, TXT)
-
-        when:
-        def records = run(lookup)
-
-        then:
-        lookup.getResult() == SUCCESSFUL
-        records.size() == 4
-
-        records.each { assert it.getTTL() == config.getTtl() }
-        records.each { assert it.getName().toString().startsWith(name) }
-        records.each { assert it.getDClass() == IN }
-        records.each { assert it.getType() == TXT }
-
-        when: "weed out urls"
-        def urls = records.collect { ((TXTRecord) it).getStrings().join("") }
-
-        then:
-        urls[0] == 'http://host-100.us-west-2.compute.internal:8080/'
-        urls[1] == 'http://host-101.us-west-2.compute.internal/'
-        urls[2] == 'https://host-102.us-west-2.compute.internal/'
-        urls[3] == 'https://host-104.us-west-2.compute.internal:8443/'
-
-        where:
-        name << [
-                "corse.service.${domain}",
-                "corse.service.${domain}.",
-                "corse.service.default.${domain}",
-                "corse.service.default.${domain}.",
-        ]
-    }
-
-    def "should correctly respond to TXT query in non-default region: #name"() {
-        given:
-        def lookup = lookup(name, TXT)
-
-        when:
-        def records = run(lookup)
-
-        then:
-        lookup.getResult() == SUCCESSFUL
-        records.size() == 1
-
-        records.each { assert it.getTTL() == config.getTtl() }
-        records.each { assert it.getName().toString().startsWith(name) }
-        records.each { assert it.getDClass() == IN }
-        records.each { assert it.getType() == TXT }
-
-        // check url
-        records[0].getStrings().join("") == "http://host-152.us-west-2.compute.internal:8080/"
-
-        where:
-        name << [
-                "mallorca.service.dc1.${domain}",
-                "mallorca.service.dc1.${domain}.",
-        ]
-    }
-
-    def "should return empty set of TXT records for unknown service"() {
-        def lookup = lookup("foo.service.${domain}.", TXT)
-
-        when:
-        def records = run(lookup)
-
-        then:
-        lookup.getResult() == HOST_NOT_FOUND
-        records.isEmpty()
-    }
-
-    //
-    // BEGIN: RFC2782
-    //
-
-    def "should correctly respond SRV records for: #name"() {
-        given:
-        def lookup = lookup(name, SRV)
-
-        when:
-        def records = run(lookup)
-        log.info("records: {}", records)
-
-        then:
-        //lookup.getResult() == SUCCESSFUL
-        records.size() == config.getMaxResponses()
-
-        records.each { assert it.getTTL() == config.getTtl() }
-        records.each { assert it.getName().toString().startsWith(name) }
-        records.each { assert it.getDClass() == IN }
-        records.each { assert it.getType() == SRV }
-
-        where:
-        name << [
-                "corse.service.${domain}",
-                "corse.service.default.${domain}",
-
-                "_corse._tcp.service.${domain}.",
-                "_corse._tcp.service.default.${domain}",
-                "_corse._tcp.service.default.${domain}.",
-        ]
-    }
-
-    //
-    // END:   RFC2782
-    //
 }

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/EurekaDnsServerSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/EurekaDnsServerSpec.groovy
@@ -296,17 +296,4 @@ class EurekaDnsServerSpec extends Specification {
                        .setEurekaClient(eurekaClient)
                        .setEventLoopGroup(eventLoopGroup)
     }
-
-//    static Resolver resolver(String host) {
-//        def r = new SimpleResolver(new InetSocketAddress(host, PORT))
-//        r.setTimeout(0, 50)
-//        r.setIgnoreTruncation(false)
-//        r
-//    }
-//
-//    static Lookup lookup(args) {
-//        def l = new Lookup(args)
-//        l.setResolver(resolver)
-//        l
-//    }
 }

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/client/DnsClient.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/client/DnsClient.groovy
@@ -1,0 +1,178 @@
+package com.github.bfg.eureka.dns.client
+
+import groovy.util.logging.Slf4j
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+
+/**
+ * Poor man's DNS client using <a href="https://en.wikipedia.org/wiki/Dig_(command)">dig cli binary</a>.
+ */
+@Slf4j
+class DnsClient {
+    private static final String binary = which("dig")
+
+    /**
+     * DNS server address
+     */
+    final String address
+
+    /**
+     * DNS server port
+     */
+    final int port
+
+    /**
+     * Query timeout.
+     */
+    final long timeoutMillis
+
+    /**
+     * Creates the client.
+     * @param address dns server address
+     * @param port dns server port
+     */
+    DnsClient(String address, int port, long timeoutMillis = 100) {
+        this.address = address
+        this.port = port
+        this.timeoutMillis = timeoutMillis
+    }
+
+    /**
+     * Resolves DNS query.
+     *
+     * @param name dns name to query
+     * @param type record type, default {@code A}
+     * @param dnsClass query class, default {@code IN}
+     * @return map containing resolve status and answers
+     */
+    DnsResponse resolve(String name, String type = "A", String dnsClass = "IN") {
+        def ts = System.nanoTime()
+        def command = [binary, '+tries=1', '+timeout=1', '-p', port, "@${address}",
+                       '-c', dnsClass, '-t', type, name] as String[]
+        def process = new ProcessBuilder(command).start()
+        log.debug("started command {} as {}", command.toList(), process)
+
+        // read response from stdout/stderr
+        def stdout = process.getInputStream().readLines("UTF-8").join("\n")
+        log.debug("dig stdout: {}", stdout)
+
+        def stderr = process.getErrorStream().readLines("UTF-8").join("\n")
+        if (stderr) {
+            log.warn("dig stderr: {}", stderr)
+        }
+
+        // wait for process to exit
+        if (!process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)) {
+            process.destroyForcibly()
+            throw new IllegalStateException("dig command didn't exit after $timeoutMillis msec.")
+        }
+
+        def exitCode = process.exitValue()
+        if (exitCode != 0) {
+            throw new IllegalStateException("dig command exited with status: $exitCode")
+        }
+
+        def durNanos = System.nanoTime() - ts
+        def duration = this.sprintf("%.2f", (durNanos / 1_000_000))
+
+        def res = parseResponse(stdout)
+        log.info("[{} {} {}] {} msec, {}, {} answers, {} authority, {} additional",
+                name, type, dnsClass, duration,
+                res.status, res.answers.size(), res.authorities.size(), res.additionals.size())
+
+        res
+    }
+
+    DnsResponse parseResponse(String str) {
+        def res = new DnsResponse()
+
+        def statusP = ~/status: (\w+),/
+        def sectionP = ~/^;; (\w+) SECTION:/
+
+        //log.info("parsing:\n{}", str)
+        def curSection = ''
+        str.eachLine {
+            //println("IT: $it")
+            if (!it) return
+            if (it.startsWith('; ')) return
+
+            // status?
+            def m = it =~ statusP
+            if (m.find()) {
+                res.status = m.group(1)
+                return
+            }
+
+            // new section?
+            m = it =~ sectionP
+            if (m.find()) {
+                curSection = m.group(1).toLowerCase()
+                return
+            }
+
+            if (it.startsWith(';')) return
+
+            def items = it.split('\\s+')
+            log.trace("ITEMS: '{}' -> {} -> {}", it, items[1], items)
+            def type = items[3]
+
+            def record = null
+            if (type == 'SOA') {
+                record = new SOARecord()
+                record.nameserver = fixName(items[4])
+                record.mbox = fixName(items[5])
+                record.serial = items[6].toInteger()
+                record.refresh = items[7].toInteger()
+                record.retry = items[8].toInteger()
+                record.expire = items[9].toInteger()
+                record.minTtl = items[10].toInteger()
+            } else if (type == 'SRV') {
+                record = new SRVRecord()
+                record.priority = items[4].toInteger()
+                record.weight = items[5].toInteger()
+                record.port = items[6].toInteger()
+                record.target = items[7]
+            } else {
+                record = new GenericRecord()
+                record.answer = fixName(items[4])
+            }
+
+            record.name = items[0].replaceAll('\\.$', '')
+            record.ttl = items[1].toInteger()
+            record.dnsClass = items[2]
+            record.type = type
+            log.debug("created record: {} {} -> {}", curSection, items[1], record)
+
+            // add record
+            if (curSection == 'answer') {
+                res.answers << record
+            } else if (curSection == 'authority') {
+                res.authorities << record
+            } else if (curSection == 'additional') {
+                res.additionals << record
+            }
+        }
+
+        res
+    }
+
+    String fixName(String s) {
+        s.replaceAll('"', '')
+         .replaceAll('\\.$', '')
+    }
+
+    private static String which(String binary) {
+        def path = System.getenv("PATH").split('\\s*[;:]+\\s*')
+                         .findAll { Files.isDirectory(Paths.get(it)) }
+                         .collect { it + File.separator + binary }
+                         .find { Files.isExecutable(Paths.get(it)) }
+
+        if (!path) {
+            throw new IllegalStateException("Cannot find zdns in PATH; install it from https://github.com/zmap/zdns")
+        }
+
+        path.toString()
+    }
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/client/DnsClientSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/client/DnsClientSpec.groovy
@@ -1,0 +1,30 @@
+package com.github.bfg.eureka.dns.client
+
+import groovy.util.logging.Slf4j
+import spock.lang.Specification
+
+@Slf4j
+class DnsClientSpec extends Specification {
+    def "should correctly resolve simple dns name"() {
+        given:
+        def query = "www.google.com"
+        def client = new DnsClient("8.8.8.8", 53)
+
+        when:
+        def res = client.resolve(query)
+        log.info("resolved: {}", res)
+        log.info("answers: {}", res.answers.size())
+
+        then:
+        res.status == "NOERROR"
+
+        def answers = res.answers
+        answers.size() >= 1
+
+        answers.each { assert it.ttl > 0 }
+        answers.each { assert it.dnsClass == "IN" }
+        answers.each { assert it.type == "A" }
+        answers.each { assert it.name == query }
+        answers.each { assert it.answer.matches('^\\d+\\.\\d+\\.\\d+\\.\\d+$') }
+    }
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/client/DnsResponse.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/client/DnsResponse.groovy
@@ -1,0 +1,12 @@
+package com.github.bfg.eureka.dns.client
+
+import groovy.transform.ToString
+
+@ToString(includePackage = false)
+class DnsResponse {
+    String status = 'UNKNOWN'
+    String error = ''
+    List<Record> answers = []
+    List<Record> authorities = []
+    List<Record> additionals = []
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/client/Record.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/client/Record.groovy
@@ -1,0 +1,40 @@
+package com.github.bfg.eureka.dns.client
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+
+@ToString(includePackage = false, includeNames = true)
+@EqualsAndHashCode
+abstract class Record {
+    String name
+    int ttl
+    String dnsClass
+    String type
+}
+
+@ToString(includePackage = false, includeNames = true, includeSuperProperties = true)
+@EqualsAndHashCode(callSuper = true)
+class GenericRecord extends Record {
+    String answer
+}
+
+@ToString(includePackage = false, includeNames = true, includeSuperProperties = true)
+@EqualsAndHashCode(callSuper = true)
+class SOARecord extends Record {
+    String nameserver
+    String mbox
+    int serial
+    int refresh
+    int retry
+    int expire
+    int minTtl
+}
+
+@ToString(includePackage = false, includeNames = true, includeSuperProperties = true)
+@EqualsAndHashCode(callSuper = true)
+class SRVRecord extends Record {
+    int priority
+    int weight
+    int port
+    String target
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/EurekaDnsServerConfigurationSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/EurekaDnsServerConfigurationSpec.groovy
@@ -1,0 +1,76 @@
+package com.github.bfg.eureka.dns.spring
+
+import com.github.bfg.eureka.dns.DnsServerConfig
+import com.netflix.discovery.EurekaClient
+import groovy.util.logging.Slf4j
+import io.netty.channel.nio.NioEventLoopGroup
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Slf4j
+@Unroll
+class EurekaDnsServerConfigurationSpec extends Specification {
+    def instance = new EurekaDnsServerConfiguration()
+
+    def "eurekaDnsServer() should throw on null arguments"() {
+        if (config && eurekaClient) return
+
+        when:
+        def server = instance.eurekaDnsServer(config, eurekaClient)
+
+        then:
+        thrown(NullPointerException)
+        server == null
+
+        where:
+        [config, eurekaClient] << [[new DnsServerConfig(), null], [Mock(EurekaClient), null]].combinations()
+    }
+
+    def "should create started dns instance using native event loop group: #preferNativeTransport"() {
+        given: "setup eureka client"
+        def eurekaClientA = Mock(EurekaClient)
+        def eurekaClientB = Mock(EurekaClient)
+
+        and: "setup eureka config"
+        def config = new DnsServerConfig()
+                .setMaxResponses(2)
+                .setPort(8553)
+                .setMaxThreads(3)
+                .setEurekaClient(eurekaClientA)
+                .setPreferNativeTransport(preferNativeTransport)
+
+        when: "create server with second eureka client"
+        def server = instance.eurekaDnsServer(config, eurekaClientB)
+
+        then:
+        def rtConfig = server.config
+
+        !rtConfig.is(config) // server should have it's own config instance
+        rtConfig.getEurekaClient().is(eurekaClientB) // should contain correct eureka client
+
+        // runtime config should be equal to original config when eureka client is removed
+        rtConfig.clone().setEurekaClient(null) == config.clone().setEurekaClient(null)
+
+        // server should be running
+        server.isRunning()
+
+        // event loop should have correct number of workers
+        server.eventLoopGroup.executorCount() == config.getMaxThreads()
+
+        // test event loop group type
+        if (preferNativeTransport) {
+            def elgClass = server.eventLoopGroup.getClass().getName()
+            assert elgClass == "io.netty.channel.epoll.EpollEventLoopGroup" || elgClass == "io.netty.channel.kqueue.KQueueEventLoopGroup"
+        } else {
+            assert server.eventLoopGroup instanceof NioEventLoopGroup
+        }
+
+        cleanup:
+        if (server?.isRunning()) {
+            server.close()
+        }
+
+        where:
+        preferNativeTransport << [true, false]
+    }
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringApp.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringApp.groovy
@@ -1,0 +1,55 @@
+package com.github.bfg.eureka.dns.spring
+
+import com.github.bfg.eureka.dns.ConfigHolder
+import com.github.bfg.eureka.dns.DnsServerConfig
+import com.github.bfg.eureka.dns.EurekaDnsServer
+import com.github.bfg.eureka.dns.FakeEurekaClient
+import com.netflix.discovery.EurekaClient
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Scope
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+import javax.annotation.PostConstruct
+
+@Slf4j
+@RestController
+@SpringBootApplication
+@EnableEurekaDnsServer
+class SpringApp {
+    @Autowired
+    DnsServerConfig config
+
+    void main(String... args) {
+        log.info("running spring app")
+        SpringApplication.run(SpringApp, args)
+    }
+
+    @PostConstruct
+    void init() {
+        log.info("app initialized with dns server config: {}", config)
+        ConfigHolder.set(config)
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+    EurekaClient eurekaClient() {
+        FakeEurekaClient.defaults()
+    }
+
+    @Bean
+    String fooString(EurekaDnsServer server) {
+        ConfigHolder.set(server.config)
+        "fooString"
+    }
+
+    @GetMapping("/")
+    String foo() {
+        "foo"
+    }
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppITSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppITSpec.groovy
@@ -1,8 +1,8 @@
 package com.github.bfg.eureka.dns.spring
 
 import com.github.bfg.eureka.dns.ConfigHolder
+import com.github.bfg.eureka.dns.DnsIntegrationSpec
 import com.github.bfg.eureka.dns.DnsServerConfig
-import com.github.bfg.eureka.dns.EurekaDnsServerITSpec
 import groovy.util.logging.Slf4j
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -11,7 +11,7 @@ import org.yaml.snakeyaml.Yaml
 @Slf4j
 @SpringBootTest(classes = SpringApp)
 @ActiveProfiles("test")
-class SpringAppITSpec extends EurekaDnsServerITSpec {
+class SpringAppITSpec extends DnsIntegrationSpec {
     def setupSpec() {
         ConfigHolder.set(readSpringDnsServerConfig())
     }

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppITSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppITSpec.groovy
@@ -1,0 +1,42 @@
+package com.github.bfg.eureka.dns.spring
+
+import com.github.bfg.eureka.dns.ConfigHolder
+import com.github.bfg.eureka.dns.DnsServerConfig
+import com.github.bfg.eureka.dns.EurekaDnsServerITSpec
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.yaml.snakeyaml.Yaml
+
+@Slf4j
+@SpringBootTest(classes = SpringApp)
+@ActiveProfiles("test")
+class SpringAppITSpec extends EurekaDnsServerITSpec {
+    def setupSpec() {
+        ConfigHolder.set(readSpringDnsServerConfig())
+    }
+
+    DnsServerConfig readSpringDnsServerConfig() {
+        def input = getClass().getResourceAsStream("/application.yml")
+        def yaml = new Yaml()
+        def iterator = yaml.loadAll(input)
+        def cfg = iterator.find { it?.eureka?.dns?.server }
+        def map = cfg.eureka.dns.server
+
+        def config = new DnsServerConfig()
+                .setPort(map.port)
+                .setTtl(map.ttl)
+                .setMaxResponses(map."max-responses")
+                .setMaxThreads(map."max-threads")
+                .setPreferNativeTransport(map."prefer-native-transport")
+                .setDomain(map.domain)
+                .setLogQueries(map."log-queries")
+        log.info("read spring dns server config: {}", config)
+        config
+    }
+
+    @Override
+    DnsServerConfig getConfig() {
+        ConfigHolder.get()
+    }
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppSpec.groovy
@@ -1,0 +1,77 @@
+package com.github.bfg.eureka.dns.spring
+
+import com.github.bfg.eureka.dns.DnsServerConfig
+import com.github.bfg.eureka.dns.EurekaDnsServer
+import groovy.util.logging.Slf4j
+import io.netty.channel.nio.NioEventLoopGroup
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+
+@Slf4j
+class SpringAppSpec extends SpringSpec {
+    @Autowired
+    ApplicationContext appCtx
+
+    @Autowired
+    EurekaDnsServer server
+
+    @Autowired
+    DnsServerConfig config
+
+    def "should wire dependencies"() {
+        expect:
+        appCtx != null
+        server != null
+        config != null
+    }
+
+    def "wired config should contain correct values"() {
+        log.info("assigned config: {}", config)
+
+        expect:
+        config.getPort() == 9553
+        config.getAddresses() == ['127.0.0.1', '::1'] as Set
+        config.getTtl() == 9
+        config.getMaxResponses() == 4
+        config.getMaxThreads() == 7
+        !config.isPreferNativeTransport()
+        config.getDomain() == 'my-eureka'
+        config.isLogQueries()
+    }
+
+    def "server should be running and should be correctly configured"() {
+        expect:
+        server.isRunning()
+
+        // server should contain it's own config instance
+        !server.config.is(config)
+
+        // server should contain equal copy of configuration without eureka client
+        def serverConfigWithoutEureka = server.config.clone().setEurekaClient(null)
+        serverConfigWithoutEureka == config
+
+        // check event loop group
+        server.eventLoopGroup instanceof NioEventLoopGroup
+        server.eventLoopGroup.executorCount() == config.getMaxThreads()
+    }
+
+    def "application context should return singleton dns server instance by class"() {
+        when:
+        def servers = (1..10).collect { appCtx.getBean(EurekaDnsServer) }
+        def first = servers.first()
+
+        then:
+        first != null
+        servers.each { assert it.is(first) }
+    }
+
+    def "application context should return singleton dns server instance by name"() {
+        when:
+        def servers = (1..10).collect { appCtx.getBean("eurekaDnsServer") }
+        def first = servers.first()
+
+        then:
+        first != null
+        servers.each { assert it.is(first) }
+    }
+}

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppSpec.groovy
@@ -30,7 +30,7 @@ class SpringAppSpec extends SpringSpec {
 
         expect:
         config.getPort() == 9553
-        config.getAddresses() == ['127.0.0.1', '::1'] as Set
+        config.getAddresses() == ['127.0.0.1'] as Set
         config.getTtl() == 9
         config.getMaxResponses() == 4
         config.getMaxThreads() == 7

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringSpec.groovy
@@ -1,0 +1,10 @@
+package com.github.bfg.eureka.dns.spring
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import spock.lang.Specification
+
+@SpringBootTest
+@ActiveProfiles("test")
+abstract class SpringSpec extends Specification {
+}

--- a/eureka-dns-server/src/test/resources/application.yml
+++ b/eureka-dns-server/src/test/resources/application.yml
@@ -1,0 +1,28 @@
+#
+#
+#
+
+spring.application.name: my-super-app
+
+# default profile doesn't have eureka DNS server configuration
+
+---
+#
+# test profile contains eureka dns server config
+#
+spring.profiles: test
+
+eureka:
+  dns:
+    server:
+      port: 9553
+      addresses: 127.0.0.1
+      ttl: 9
+      max-responses: 4
+      max-threads: 7
+      prefer-native-transport: false
+      domain: my-eureka
+      log-queries: true
+
+# vim:shiftwidth=2 softtabstop=2 expandtab
+# EOF


### PR DESCRIPTION
### Motivation:

Eureka is often run as spring-boot application, therefore is sensible to run eureka-dns-server in the same jvm instance as eureka server itself.

### Modification:

Implemented spring support for bootstraping dns server.

### Result:

Eureka running as spring-boot app can also start dns server.