### PR TITLE
Added support for publishing to Sonatype maven central

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,11 @@ jobs:
 
       - run:
           name: Upload test coverage reports
-          command: bash <(curl -s https://codecov.io/bash)
+          command: test -z "$CIRCLE_PR_USERNAME" && bash <(curl -s https://codecov.io/bash)
+
+      - run:
+          name: Upload artifacts to maven repository
+          command: test -z "$CIRCLE_PR_USERNAME" && ./gradlew eureka-dns-server:uploadArchives
 
       # setup remote docker
       - setup_remote_docker:
@@ -52,12 +56,12 @@ jobs:
       # login to docker hub
       - run:
           name: Docker hub login
-          command: docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+          command: test -z "$CIRCLE_PR_USERNAME" && docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 
       # build and push docker image
       - run:
           name: Build and push docker image
-          command: ./gradlew eureka-dns-server-standalone:{docker,dockerPush}
+          command: test -z "$CIRCLE_PR_USERNAME" && ./gradlew eureka-dns-server-standalone:{docker,dockerPush}
 
 # vim:shiftwidth=2 softtabstop=2 expandtab
 # EOF

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,18 @@ plugins {
   id "com.adarshr.test-logger"              version "1.6.0"
 }
 
+ext.isReleaseVersion = !version.contains("-SNAPSHOT")
+def getProjectProp(name, defaultValue) {
+  if (project.hasProperty(name)) {
+    return project.getProperties().get(name)
+  }
+
+  // consult env vars
+  def envVarName = name.toUpperCase().replace(".", "_")
+  def envVarValue = System.getenv(envVarName)
+  return (envVarValue) ? envVarValue : defaultValue
+}
+
 allprojects {
   apply plugin: "java"
   apply plugin: "groovy"
@@ -32,6 +44,7 @@ allprojects {
   apply plugin: "eclipse"
   apply plugin: "maven"
   apply plugin: "maven-publish"
+  apply plugin: "signing"
   apply plugin: "io.spring.dependency-management"
   apply plugin: "com.adarshr.test-logger"
 
@@ -129,6 +142,69 @@ allprojects {
             }
             if (tasks.findByName("javadocJar")) {
               artifact javadocJar
+            }
+          }
+        }
+      }
+    }
+  }
+
+  artifacts {
+    archives jar
+    archives sourcesJar
+    archives javadocJar
+  }
+
+  signing {
+    required { isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
+  }
+
+  uploadArchives {
+    repositories {
+      mavenDeployer {
+        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+        repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+          authentication(
+                  userName: getProjectProp('osshr.user', 'some-osshr-user'),
+                  password: getProjectProp('osshr.pass', 'some-osshr-pass'))
+        }
+
+        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+          authentication(
+                  userName: getProjectProp('osshr.user', 'some-osshr-user'),
+                  password: getProjectProp('osshr.pass', 'some-osshr-pass'))
+        }
+
+        pom.project {
+          name        "Eureka DNS server"
+          packaging   "jar"
+          description "DNS server interface to Eureka service registry"
+          url         "https://github.com/bfg/eureka-dns-server/"
+
+          scm {
+            connection          "scm:git:https://github.com/bfg/eureka-dns-server.git"
+            developerConnection "scm:git:https://github.com/bfg/eureka-dns-server.git"
+            url                 "https://github.com/bfg/eureka-dns-server/"
+          }
+
+          licenses {
+            license {
+              name "The Apache License, Version 2.0"
+              url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          }
+
+          developers {
+            developer {
+              id    "bfg"
+              name  "Brane F. Gračnar"
+            }
+            developer {
+              id    "github"
+              name  "Github project contributors"
+              url   "https://github.com/bfg/eureka-dns-server/graphs/contributors"
             }
           }
         }

--- a/eureka-dns-server-standalone/build.gradle
+++ b/eureka-dns-server-standalone/build.gradle
@@ -67,7 +67,7 @@ shadowJar {
 
   mergeServiceFiles()
 }
-build.finalizedBy shadowJar
+//build.finalizedBy shadowJar
 
 // docker support
 docker {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 group=com.github.bfg.eureka
-version=1.0.0-SNAPSHOT
+version=0.9.0-SNAPSHOT
 
+# org.gradle.caching=true
 org.gradle.warning.mode=all


### PR DESCRIPTION
### Motivation:

We want to publish artifact to maven central, so that is easy to consume.

### Modification:

Added support for publishing to maven central/sonaty osshr snapshots