### PR TITLE
Require explicit enabling of dns server in spring environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
       - run:
           name: Upload artifacts to maven repository
           command: |
+            echo "CIRCLE_PR_USERNAME: '$CIRCLE_PR_USERNAME'"
+            echo "CIRCLE_TAG:         '$CIRCLE_TAG'"
             if [ -z "$CIRCLE_PR_USERNAME" -a -z "$CIRCLE_TAG" ]; then
               ./gradlew eureka-dns-server:publish
             fi

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ application by annotating application starter class with `@EnableEurekaDnsServer
 eureka:
   dns:
     server:
+      # by default, dns server is disabled
+      enabled: true
+
       # server listening port, default: 8553
       port: 8553
 

--- a/README.md
+++ b/README.md
@@ -117,22 +117,61 @@ commonly able to process UDP packets with payload size up to 4096 bytes.
 
 # Usage
 
-To use eureka-dns-server, you need at least java 8 runtime, java 11 should work as well.
+To use `eureka-dns-server`, you need at least java 8 runtime, java 11 works as well.
 
-##### maven
+### maven
 
+**release**
 ```xml
 <dependency>
     <groupId>com.github.bfg.eureka</groupId>
     <artifactId>eureka-dns-server</artifactId>
-    <version>latest-version</version>
+    <version>x.y.z</version>
 </dependency>
 ```
 
-##### gradle   
+**snapshot**
+
+```xml
+<repositories>
+  <repository>
+    <id>snapshots-repo</id>
+    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    <releases><enabled>false</enabled></releases>
+    <snapshots><enabled>true</enabled></snapshots>
+  </repository>
+</repositories>
+
+<dependencies>
+  <dependency>
+    <groupId>com.github.bfg.eureka</groupId>
+    <artifactId>eureka-dns-server</artifactId>
+    <version>x.y.z-SNAPSHOT</version>
+  </dependency>
+</dependencies>
+```
+
+### gradle   
+
+**release**
+```gradle
+dependencies {
+  implementation  "com.github.bfg.eureka:eureka-dns-server:x.y.z"
+}
+```
+
+**snapshot**
 
 ```gradle
-compile     "com.github.bfg.eureka:eureka-dns-server:<latest-version>"
+repositories {
+  mavenLocal()
+  mavenCentral()
+  maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+}
+
+dependencies {
+  implementation  "com.github.bfg.eureka:eureka-dns-server:x.y.z-SNAPSHOT"
+}
 ```
 
 # Running
@@ -151,7 +190,7 @@ application by annotating application starter class with `@EnableEurekaDnsServer
 eureka:
   dns:
     server:
-      # by default, dns server is disabled
+      # dns server is disabled by default
       enabled: true
 
       # server listening port, default: 8553
@@ -235,13 +274,12 @@ different DNS servers.
 
 # Building
 
-To build this project you need at least JDK 8 installed. You also need `dig` installed because it's being used by 
-integration tests.
+To build this project you need at least JDK 11 installed, but code is compiled to JDK8 bytecode. You also need `dig`
+installed because it's being used by integration tests.
 
 ```bash
 ./gradlew clean build
 ```
-
 # Performance
 
 Eureka DNS server is built on top of [netty](https://netty.io/) and is able to utilize epoll/kqueue based transports
@@ -305,6 +343,63 @@ Statistics:
   Latency StdDev (s):   0.000571
 ```
 
+# Releasing
+
+Publishing releases to maven central is a bit tricky; project needs to align with
+[maven central requirements](https://central.sonatype.org/pages/requirements.html). Docker image is published to
+[docker hub][docker image] automatically by [CI][CI].
+
+#### Create and publish PGP key
+```
+gpg --full-gen-key
+```
+* publish created *public* key to public key registry
+```
+gpg --send-key --keyserver pool.sks-keyservers.net <keyid>
+```
+
+* setup ~/.gradle/gradle.properties
+```properties
+#
+# gradle.properties
+#
+
+# requires useGpgCmd() signing {} block
+signing.gnupg.keyName=<keyid>
+
+# vim:syntax=jproperties
+# EOF
+```
+
+#### Create release
+
+```
+git checkout master
+./gradlew release
+```
+
+#### Publish release to maven central staging repository
+
+* checkout correct tag
+```
+git checkout x.y.z
+```
+
+* build the project
+```
+./gradlew clean build
+```
+
+* publish release to Sonatype central staging
+
+```
+./gradlew publish
+```
+
+* follow [Sonatype OSSRH instructions](https://central.sonatype.org/pages/releasing-the-deployment.html) to release the
+publication
+
 [docker image]: https://cloud.docker.com/repository/docker/gracnar/eureka-dns-server/
 [standalone module]: eureka-dns-server-standalone
 [dnsperf]: https://github.com/DNS-OARC/dnsperf
+[CI]: https://circleci.com/gh/bfg/eureka-dns-server

--- a/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/spring/EurekaDnsServerConfiguration.java
+++ b/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/spring/EurekaDnsServerConfiguration.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -29,6 +30,7 @@ public class EurekaDnsServerConfiguration {
     @Bean
     @SneakyThrows
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(value = "eureka.dns.server.enabled")
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
     public EurekaDnsServer eurekaDnsServer(@NonNull DnsServerConfig config, @NonNull EurekaClient eurekaClient) {
         val server = config.clone()

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringApp.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringApp.groovy
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Scope
 import org.springframework.web.bind.annotation.GetMapping
@@ -43,6 +44,7 @@ class SpringApp {
     }
 
     @Bean
+    @ConditionalOnBean(EurekaDnsServer)
     String fooString(EurekaDnsServer server) {
         ConfigHolder.set(server.config)
         "fooString"

--- a/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppDisabledSpec.groovy
+++ b/eureka-dns-server/src/test/groovy/com/github/bfg/eureka/dns/spring/SpringAppDisabledSpec.groovy
@@ -1,0 +1,34 @@
+package com.github.bfg.eureka.dns.spring
+
+import com.github.bfg.eureka.dns.DnsServerConfig
+import com.github.bfg.eureka.dns.EurekaDnsServer
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.ActiveProfiles
+
+@Slf4j
+@ActiveProfiles(profiles = "default", inheritProfiles = false)
+class SpringAppDisabledSpec extends SpringSpec {
+    @Autowired
+    ApplicationContext appCtx
+
+    @Autowired
+    DnsServerConfig config
+
+    def "should wire dependencies"() {
+        expect:
+        appCtx != null
+        config != null
+    }
+
+    def "server bean should not be initialized"() {
+        when:
+        def server = appCtx.getBean(EurekaDnsServer)
+
+        then:
+        thrown(NoSuchBeanDefinitionException)
+        server == null
+    }
+}

--- a/eureka-dns-server/src/test/resources/application.yml
+++ b/eureka-dns-server/src/test/resources/application.yml
@@ -15,6 +15,7 @@ spring.profiles: test
 eureka:
   dns:
     server:
+      enabled: true
       port: 9553
       addresses: 127.0.0.1
       ttl: 9


### PR DESCRIPTION
This PR adds requirement that DNS server needs to be explicitly enabled in configuration in order to be started automatically.