### PR TITLE
Update DnsQueryHandler.java

### DIFF
--- a/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/DnsQueryHandler.java
+++ b/eureka-dns-server/src/main/java/com/github/bfg/eureka/dns/DnsQueryHandler.java
@@ -57,7 +57,7 @@ final class DnsQueryHandler extends SimpleChannelInboundHandler<DatagramDnsQuery
     private static final Set<DnsRecordType> VALID_QUESTION_TYPES = Collections.unmodifiableSet(new LinkedHashSet<>(
             Arrays.asList(A, AAAA, ANY, TXT, SRV, DS, SOA, NS)));
 
-    private static final String SERVICE_NAME_REGEX = "^_?([\\w\\-]+)\\.(?:_\\w+\\.)?(?:service|connect)\\.";
+    private static final String SERVICE_NAME_REGEX = "^_?([\\w\\-\\.]+)\\.(?:_\\w+\\.)?(?:service|connect)\\.";
     private static final String DATACENTER_REGEX = "([\\w\\-]+)\\.";
 
 


### PR DESCRIPTION
Allow dot character (.) in service names

### Motivation:

Currently queries of the form \<name\>.service.\<domain\> are supported. \<name\> values cannot have the dot character. Services in our project tend to have the dot character. This change adds support for the dot character in \<name\>.

### Modification:

Solution is simple. SERVICE_NAME_REGEX in DnsQueryHandler needs minor change.  Add \\\\. in the first capturing group. I.e. 

`private static final String SERVICE_NAME_REGEX = "^_?([\\w\\-\\.]+)\\.(?:_\\w+\\.)?(?:service|connect)\\.";`

### Result:

Fixes #20 . 
